### PR TITLE
add warning for generate_random_word

### DIFF
--- a/src/aiamplitudes_common_public/rels_utils.py
+++ b/src/aiamplitudes_common_public/rels_utils.py
@@ -422,6 +422,7 @@ def get_dihedral_pair(key, goodkeys, symb, type="cycle"):
 def generate_random_word(word_length, format='full', seed=0):
     '''
     Generate a random word with a specific length.
+    Does not account for Steinmann adjacency relations, so is likely to give a zero-coef word.
     ---------
     INPUTS:
     word_length: int; number of letters in the generated word.


### PR DESCRIPTION
Add warning flag to warn against calling generate_random_word when a zero-coef word is not desired.